### PR TITLE
Fix redundant parsing of exclude-dirs param

### DIFF
--- a/yandex-disk-indicator.py
+++ b/yandex-disk-indicator.py
@@ -819,11 +819,6 @@ class YDDaemon(object):         # Yandex.Disk daemon interface
         self['overwrite'] = (self.get('overwrite', False) == '')
         self.setdefault('startonstartofindicator', True)    # New value to start daemon individually
         self.setdefault('stoponexitfromindicator', False)   # New value to stop daemon individually
-        exDirs = self.get('exclude-dirs', None)
-        if exDirs is None:
-          self['exclude-dirs'] = None
-        else:
-          self['exclude-dirs'] = self.getValue(exDirs)
         return True
       else:
         return False


### PR DESCRIPTION
There are some items in exclude-dir param. Get error on run (stack trace below) because 'exclude-dirs' param already parsed and contains python list.
  File "/usr/bin/yandex-disk-indicator", line 1291, in <module>
    len(indicators), len(daemons) > 1))
  File "/usr/bin/yandex-disk-indicator", line 936, in **init**
    self.daemon = YDDaemon(path)
  File "/usr/bin/yandex-disk-indicator", line 304, in **init**
    while not self.config.load():   # Try to read Yandex.Disk configuration file
  File "/usr/bin/yandex-disk-indicator", line 293, in load
    self['exclude-dirs'] = self.getValue(exDirs)
  File "/usr/bin/yandex-disk-indicator", line 125, in getValue
    words = re.findall(r'("[^"]*")|([~/.\w-]+)', st)  # Get list of values
  File "/usr/lib/python3.4/re.py", line 210, in findall
    return _compile(pattern, flags).findall(string)
TypeError: expected string or buffer
