### PR TITLE
Added actions for file manager

### DIFF
--- a/fm-actions/Nautilus_Nemo/publish_yd.desktop
+++ b/fm-actions/Nautilus_Nemo/publish_yd.desktop
@@ -1,0 +1,15 @@
+[Desktop Entry]
+Type=Action
+Name=Add public link on Yandex.Disk
+Name[ru]=Опубликовать через Яндекс.Диск
+Icon=/usr/share/yd-tools/icons/yd-128.png
+Icon[ru]=/usr/share/yd-tools/icons/yd-128.png
+ToolbarLabel=Add public link on Yandex.Disk
+ToolbarLabel[ru]=Опубликовать через Яндекс.Диск
+Profiles=profile-zero;
+
+[X-Action-Profile profile-zero]
+Name=Add public link on Yandex.Disk
+Name[ru]=Опубликовать через Яндекс.Диск
+Exec=/usr/share/yd-tools/fm-actions/Nautilus_Nemo/publish %f
+NotShowIn=KDE;

--- a/fm-actions/Nautilus_Nemo/unpublish_yd.desktop
+++ b/fm-actions/Nautilus_Nemo/unpublish_yd.desktop
@@ -1,0 +1,15 @@
+[Desktop Entry]
+Type=Action
+Name=Remove public link from Yandex.Disk
+Name[ru]=Убрать из публикации через Яндекс.Диск
+Icon=/usr/share/yd-tools/icons/yd-128_g.png
+Icon[ru_RU]=/usr/share/yd-tools/icons/yd-128_g.png
+ToolbarLabel[ru_RU]=unpublish
+ToolbarLabel[ru]=unpublish
+Profiles=profile-zero;
+
+[X-Action-Profile profile-zero]
+Name=Remove public link from Yandex.Disk
+Name[ru]=Убрать из публикации через Яндекс.Диск
+Exec=/usr/share/yd-tools/fm-actions/Nautilus_Nemo/unpublish %f
+NotShowIn=KDE;

--- a/ya-setup
+++ b/ya-setup
@@ -50,16 +50,23 @@ exit 1
 fi
 
 ###Folder
+action_pub='/usr/share/yd-tools/fm-actions/Nautilus_Nemo/publish_yd.desktop'
+action_unpub='/usr/share/yd-tools/fm-actions/Nautilus_Nemo/unpublish_yd.desktop'
+mkdir -p $HOME/.local/share/file-manager/actions
+cp -fr $action_pub $action_unpub $HOME/.local/share/file-manager/actions
 ans=$(zenity  --list --cancel-label="$_Exit" --ok-label="$_Next" --title "$_YD_setup_title" --text "$_Folder_body" --radiolist --hide-header --column "" --column "$_Options" TRUE "$_Default" FALSE "$_Existing")
 if [ $? -eq "0" ];then
 	if [ "$ans" = "$_Default" ]; then
 	mkdir /home/$USER/Yandex.Disk
 	echo "dir=\"/home/$USER/Yandex.Disk\"" >> $conf
-
+	echo "Folders=/home/$USER/Yandex.Disk" >> $HOME/.local/share/file-manager/actions/publish_yd.desktop
+	echo "Folders=/home/$USER/Yandex.Disk" >> $HOME/.local/share/file-manager/actions/unpublish_yd.desktop
 	else
 		if [ "$ans" = "$_Existing" ]; then
 		folder=`zenity --file-selection --directory --title="$_Select_folder"`
 		echo "dir=\"$folder\"" >> $conf
+		echo "Folders=$folder" >> $HOME/.local/share/file-manager/actions/publish_yd.desktop
+		echo "Folders=$folder" >> $HOME/.local/share/file-manager/actions/unpublish_yd.desktop
 		fi
 	fi
 else


### PR DESCRIPTION
Я написал actions, которые должны работать в основных файловых менеджерах: nautilus, nemo, caja, thunar, pcmanfm. Все эти файловые менеджеры поддерживают действия вида $HOME/.local/share/file-manager/ваше_действие.desktop Также я подправил /usr/share/yd-tools/ya-setup, чтобы он автоматически устанавливал их в $HOME/.local/share/file-manager.
