### PR TITLE
Fix for error in "Add excluded folder" dialog

### DIFF
--- a/yandex-disk-indicator.py
+++ b/yandex-disk-indicator.py
@@ -1073,7 +1073,7 @@ class Preferences(Gtk.Dialog):  # Preferences window of application and daemons
       rootDir = self.dconfig['dir']
       dialog.set_current_folder(rootDir)
       if dialog.run() == Gtk.ResponseType.ACCEPT:
-        self.excList.append([False, relativePath(dialog.get_filename(), start=rootDir)])
+        self.exList.append([False, relativePath(dialog.get_filename(), start=rootDir)])
         self.dconfig.changed = True
       dialog.destroy()
 


### PR DESCRIPTION
Because of the typo in field name it resulted in

```
Traceback (most recent call last):
  File "/usr/bin/yandex-disk-indicator", line 1076, in addFolder
     self.excList.append([False, relativePath(dialog.get_filename(), start=rootDir)])
AttributeError: 'excludeDirsList' object has no attribute 'excList'
```
