### PR TITLE
add Ayatana indicator support for Debian 11

### DIFF
--- a/build/yd-tools/debian/control
+++ b/build/yd-tools/debian/control
@@ -9,7 +9,7 @@ X-Python-Version: >= 3.5
 Package: yd-tools
 Architecture: all
 Section: python
-Depends: ${misc:Depends}, python3, python3-pyinotify, python3-gi, gir1.2-glib-2.0, gir1.2-gtk-3.0, gir1.2-appindicator3-0.1, gir1.2-gdkpixbuf-2.0, gir1.2-notify-0.7, xclip, zenity
+Depends: ${misc:Depends}, python3, python3-pyinotify, python3-gi, gir1.2-glib-2.0, gir1.2-gtk-3.0, gir1.2-appindicator3-0.1 | gir1.2-ayatanaappindicator3-0.1, gir1.2-gdkpixbuf-2.0, gir1.2-notify-0.7, xclip, zenity
 Description: Yandex.Disk indicator for Ubuntu desktop panel.
  The application indicator is displayed within the indicator plugin.
  It uses Yandex.Disk CLI synchronization utility and shows current status and

--- a/indicator.py
+++ b/indicator.py
@@ -5,8 +5,12 @@
 from gi import require_version
 require_version('Gtk', '3.0')
 from gi.repository import Gtk
-require_version('AppIndicator3', '0.1')
-from gi.repository import AppIndicator3 as appIndicator
+try:
+    require_version('AppIndicator3', '0.1')
+    from gi.repository import AppIndicator3 as appIndicator
+except Exception:
+    require_version('AyatanaAppIndicator3', '0.1')
+    from gi.repository import AyatanaAppIndicator3 as appIndicator
 require_version('Notify', '0.7')
 from gi.repository import Notify
 require_version('GdkPixbuf', '2.0')


### PR DESCRIPTION
Modern Debian versions are shipping Ayatana indicators. 
This PR allows one to build and use universal yandex-disk-indicator package for both modern Ubuntu and Debian systems.